### PR TITLE
update simplito/elliptic-php dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         "web3p/rlp": "~0.2.1",
         "web3p/ethereum-util": "~0.1.1",
         "kornrunner/keccak": "~1",
-        "simplito/elliptic-php": "1.0.3"
+        "simplito/elliptic-php": "1.0.*"
     }
 }


### PR DESCRIPTION
Current version of simplito/elliptic-php is 1.0.4 and using multiple libraries for performing different Blockchain operation on various coins, makes us use more flexible dependency versioning.