### PR TITLE
Update to match `ArrayAccess` interface for PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ composer.lock
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
+
+.idea
+.vscode

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "PHP": "^7.1|^8.0",
+        "PHP": "^8.0",
         "web3p/rlp": "0.3.5",
         "web3p/ethereum-util": "~0.1.3",
         "kornrunner/keccak": "~1",

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -227,9 +227,10 @@ class Transaction implements ArrayAccess
         $method = 'set' . ucfirst($name);
 
         if (method_exists($this, $method)) {
-            return call_user_func_array([$this, $method], [$value]);
+            call_user_func_array([$this, $method], [$value]);
+            return;
         }
-        return $this->offsetSet($name, $value);
+        $this->offsetSet($name, $value);
     }
 
     /**
@@ -244,12 +245,12 @@ class Transaction implements ArrayAccess
 
     /**
      * Set the value in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to
-     * @param string value
+     *
+     * @param mixed $offset key, eg: to
+     * @param mixed $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 
@@ -285,11 +286,11 @@ class Transaction implements ArrayAccess
 
     /**
      * Return whether the value is in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to
+     *
+     * @param mixed $offset key, eg: to
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 
@@ -301,11 +302,11 @@ class Transaction implements ArrayAccess
 
     /**
      * Unset the value in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to
+     *
+     * @param mixed $offset key, eg: to
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 
@@ -316,11 +317,11 @@ class Transaction implements ArrayAccess
 
     /**
      * Return the value in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to 
+     *
+     * @param mixed $offset key, eg: to
      * @return mixed value of the transaction
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 

--- a/src/TypeTransaction.php
+++ b/src/TypeTransaction.php
@@ -210,9 +210,10 @@ class TypeTransaction implements ArrayAccess
         $method = 'set' . ucfirst($name);
 
         if (method_exists($this, $method)) {
-            return call_user_func_array([$this, $method], [$value]);
+            call_user_func_array([$this, $method], [$value]);
+            return;
         }
-        return $this->offsetSet($name, $value);
+        $this->offsetSet($name, $value);
     }
 
     /**
@@ -227,12 +228,12 @@ class TypeTransaction implements ArrayAccess
 
     /**
      * Set the value in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to
-     * @param string value
+     *
+     * @param mixed $offset key, eg: to
+     * @param mixed $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 
@@ -293,11 +294,11 @@ class TypeTransaction implements ArrayAccess
 
     /**
      * Return whether the value is in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to
+     *
+     * @param mixed $offset key, eg: to
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 
@@ -309,11 +310,11 @@ class TypeTransaction implements ArrayAccess
 
     /**
      * Unset the value in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to
+     *
+     * @param mixed $offset key, eg: to
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 
@@ -324,11 +325,11 @@ class TypeTransaction implements ArrayAccess
 
     /**
      * Return the value in the transaction with given key.
-     * 
-     * @param string $offset key, eg: to 
+     *
+     * @param mixed $offset key, eg: to
      * @return mixed value of the transaction
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         $txKey = isset($this->attributeMap[$offset]) ? $this->attributeMap[$offset] : null;
 


### PR DESCRIPTION
Resolves the error I get from PHP 8.1

```
Error: During inheritance of ArrayAccess: Uncaught ErrorException: Return type of
Web3p\EthereumTx\Transaction::offsetExists($offset) should either be compatible
with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute
should be used to temporarily suppress the notice in
/app/vendor/web3p/ethereum-tx/src/Transaction.php:292
```